### PR TITLE
feat(auth): implement email/password login and admin seeding

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "ts-node-dev --respawn --transpile-only ./src/index.ts"
+    "dev": "ts-node-dev --respawn --transpile-only ./src/index.ts",
+    "seed:admin": "ts-node ./src/scripts/seedAdmin.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -32,16 +32,16 @@ export class UserController {
 
     async login(req: Request, res: Response, next: NextFunction) {
         try {
-            const { firebaseUid, idToken } = req.body;
+            const { email, password } = req.body;
 
-            if (!firebaseUid || !idToken) {
-                throw new SystemError("Firebase UID e token são obrigatórios");
+            if (!email || !password) {
+                throw new SystemError("Email e senha são obrigatórios");
             }
 
-            const user = await userServices.loginUser(firebaseUid, idToken);
+            const loginResult = await userServices.loginWithEmailPassword(email, password);
             res.status(200).json({
                 success: true,
-                data: user,
+                data: loginResult,
                 message: "Login realizado com sucesso"
             });
         } catch (error) {
@@ -61,6 +61,25 @@ export class UserController {
             res.status(200).json({
                 success: true,
                 message: "Email de redefinição de senha enviado"
+            });
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async getUserData(req: Request, res: Response, next: NextFunction) {
+        try {
+            const email = req.params.email;
+
+            if (!email) {
+                throw new SystemError("Usuário não autenticado");
+            }
+
+            const userData = await userServices.getUserData(email);
+            res.status(200).json({
+                success: true,
+                data: userData,
+                message: "Dados do usuário obtidos com sucesso"
             });
         } catch (error) {
             next(error);

--- a/src/repository/UsersRepository.ts
+++ b/src/repository/UsersRepository.ts
@@ -27,15 +27,16 @@ export class UsersRepository {
         try {
             const userFirebase = await createUserWithEmailAndPassword(firebaseAuth, user.email as string, user.email as string)
 
-            await this.forgotPassword(user.email as string)
-
+            
             const userDB = await this.create({
                 email: user.email as string,
                 name: user.name as string,
                 firebaseUid: userFirebase.user.uid,
                 role: user.role as RoleEnum,
             })
-
+            
+            await this.forgotPassword(user.email as string)
+            
             return userDB
         } catch (error) {
             console.error("Erro ao criar o usuario", error)
@@ -45,6 +46,16 @@ export class UsersRepository {
 
     async forgotPassword(email: string) {
         try {
+            const user = await repository.findOne({
+                where: {
+                    email
+                }
+            })
+
+            if(!user) {
+                throw new SystemError("Email não cadastrado")
+            }
+
             await sendPasswordResetEmail(firebaseAuth, email)
         } catch (error) {
             console.error("Erro ao resetar a senha", error)
@@ -52,8 +63,6 @@ export class UsersRepository {
         }
     }
 
-
-    // Função para buscar o usuario pelo email e retornar as compras e configurações
     async getUserByEmail(email: string) {
         try {
             return await repository.findOne({

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -4,6 +4,7 @@ import { UserController } from "../controllers/UserController";
 const userController = new UserController();
 const router = Router()
 
+router.get("/user-data/:email", userController.getUserData);
 router.post("/register", userController.create);
 router.post("/login", userController.login);
 router.put("/forgot-password", userController.forgotPassword);

--- a/src/scripts/seedAdmin.ts
+++ b/src/scripts/seedAdmin.ts
@@ -1,0 +1,111 @@
+import "reflect-metadata";
+import { AppDataSource } from "../database/data-source";
+import { Users } from "../database/entities/User";
+import { RoleEnum } from "../database/enums/RoleEnum";
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from "firebase/auth";
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+import { config } from "dotenv";
+
+config();
+
+// Configuração do Firebase
+const firebaseConfig = {
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID
+};
+
+const firebaseApp = initializeApp(firebaseConfig);
+const firebaseAuth = getAuth(firebaseApp);
+
+async function seedAdminUser() {
+  try {
+    // Inicializar conexão com o banco de dados
+    await AppDataSource.initialize();
+    console.log("Conexão com o banco de dados estabelecida.");
+
+    // Obter o repositório de usuários
+    const userRepository = AppDataSource.getRepository(Users);
+
+    const adminEmail = "admin@admin.com";
+    const adminPassword = "admin123456";
+    let firebaseUid: string;
+    let shouldCreateInDB = true;
+
+    // Verificar se já existe um usuário admin no banco
+    const existingAdminInDB = await userRepository.findOne({
+      where: { email: adminEmail }
+    });
+
+    if (existingAdminInDB) {
+      console.log("Usuário admin já existe no banco de dados.");
+      return;
+    }
+
+    try {
+      // Tentar criar usuário no Firebase
+      console.log("Criando usuário no Firebase...");
+      const userFirebase = await createUserWithEmailAndPassword(firebaseAuth, adminEmail, adminPassword);
+      firebaseUid = userFirebase.user.uid;
+      console.log("Usuário criado no Firebase com sucesso. UID:", firebaseUid);
+    } catch (firebaseError: any) {
+      if (firebaseError.code === 'auth/email-already-in-use') {
+        console.log("Usuário já existe no Firebase. Fazendo login para obter UID...");
+        try {
+          // Se já existe, fazer login para obter o UID
+          const userCredential = await signInWithEmailAndPassword(firebaseAuth, adminEmail, adminPassword);
+          firebaseUid = userCredential.user.uid;
+          console.log("Login realizado com sucesso. UID obtido:", firebaseUid);
+        } catch (loginError) {
+          console.error("Erro ao fazer login no Firebase:", loginError);
+          throw loginError;
+        }
+      } else {
+        console.error("Erro ao criar usuário no Firebase:", firebaseError);
+        throw firebaseError;
+      }
+    }
+
+    // Criar usuário no banco de dados
+    if (shouldCreateInDB) {
+      console.log("Criando usuário no banco de dados...");
+      const adminUser = new Users();
+      adminUser.email = adminEmail;
+      adminUser.name = "Administrador";
+      adminUser.firebaseUid = firebaseUid;
+      adminUser.role = RoleEnum.ADMIN;
+      adminUser.isActive = true;
+
+      // Salvar no banco de dados
+      const savedUser = await userRepository.save(adminUser);
+
+      console.log("Usuário admin criado com sucesso no banco de dados:");
+      console.log({
+        id: savedUser.id,
+        email: savedUser.email,
+        name: savedUser.name,
+        role: savedUser.role,
+        firebaseUid: savedUser.firebaseUid,
+        createdAt: savedUser.createdAt,
+        validUntil: savedUser.validUntil,
+        isActive: savedUser.isActive
+      });
+    }
+
+  } catch (error) {
+    console.error("Erro ao criar usuário admin:", error);
+  } finally {
+    // Fechar conexão com o banco de dados
+    if (AppDataSource.isInitialized) {
+      await AppDataSource.destroy();
+      console.log("Conexão com o banco de dados fechada.");
+    }
+  }
+}
+
+// Executar o script
+seedAdminUser();

--- a/src/services/UserServices.ts
+++ b/src/services/UserServices.ts
@@ -1,7 +1,8 @@
-import { adminFirebase } from "..";
+import { adminFirebase, firebaseAuth } from "..";
 import { SystemError } from "../middlewares/SystemError";
 import { UsersRepository } from "../repository/UsersRepository";
 import { UsersType } from "../types/UsersType";
+import { signInWithEmailAndPassword } from "firebase/auth";
 
 const usersRepository = new UsersRepository();
 
@@ -33,6 +34,57 @@ export class UserServices {
     }
   }
 
+  async loginWithEmailPassword(email: string, password: string) {
+    try {
+      const userCredential = await signInWithEmailAndPassword(firebaseAuth, email, password);
+      const firebaseUser = userCredential.user;
+      
+      const idToken = await firebaseUser.getIdToken();
+      
+      const user = await usersRepository.getUserByEmail(email);
+      
+      if (!user) {
+        throw new SystemError("Usuário não encontrado no banco de dados");
+      }
+      
+      if (!user.isActive) {
+        throw new SystemError("Usuário inativo");
+      }
+      
+      return {
+        user: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: user.role,
+          firebaseUid: user.firebaseUid,
+          createdAt: user.createdAt
+        },
+        token: idToken,
+      };
+    } catch (error: any) {
+      console.error("Erro no login com email e senha:", error);
+      
+      if (error.code === 'auth/user-not-found') {
+        throw new SystemError("Email não encontrado");
+      }
+      
+      if (error.code === 'auth/wrong-password') {
+        throw new SystemError("Senha incorreta");
+      }
+      
+      if (error.code === 'auth/invalid-email') {
+        throw new SystemError("Email inválido");
+      }
+      
+      if (error.code === 'auth/user-disabled') {
+        throw new SystemError("Usuário desabilitado");
+      }
+      
+      throw error;
+    }
+  }
+
   async createUser(user: UsersType) {
     try {
       await usersRepository.isValidUser(user);
@@ -49,6 +101,29 @@ export class UserServices {
       await usersRepository.forgotPassword(email);
       return "Email de redefinição de senha enviado";
     } catch (error) {
+      throw error;
+    }
+  }
+
+  async getUserData(email: string) {
+    try {
+      const user = await usersRepository.getUserByEmail(email);
+
+      if (!user) {
+        throw new SystemError("Usuário não encontrado");
+      }
+
+      return {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        validUntil: user.validUntil,
+        createdAt: user.createdAt,
+        isActive: user.isActive
+      };
+    } catch (error) {
+      console.error("Erro ao buscar dados do usuário:", error);
       throw error;
     }
   }


### PR DESCRIPTION
- Add new login endpoint using email/password instead of firebaseUid
- Create getUserData endpoint to fetch user details
- Add seed:admin script to initialize admin user
- Improve forgot password flow with email validation
- Reorder user creation flow to avoid premature password reset